### PR TITLE
Hide navigation bar on Timeline screen

### DIFF
--- a/GoalsTimelineApp/TimelineViewController.swift
+++ b/GoalsTimelineApp/TimelineViewController.swift
@@ -24,6 +24,10 @@ class TimelineViewController: UIViewController, UICollectionViewDataSource, UICo
     
     override func viewWillAppear(_ animated: Bool) {
         
+        super.viewWillAppear(true)
+        //Hide navigation bar 
+        navigationController?.setNavigationBarHidden(true, animated: true)
+        
         self.fetchTimeline()
         
     }


### PR DESCRIPTION
No Back button anymore.
User cannot go back to 'create new timeline' screen after timeline is created.